### PR TITLE
Use circular sankey only when required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "factorio-lab",
   "description": "Angular-based calculator for the game Factorio",
-  "version": "1.1.61",
+  "version": "1.1.62",
   "private": true,
   "contributors": [
     "Doug Broad (https://github.com/dcbroad3)"

--- a/src/app/components/containers/flow-container/sankey/sankey.component.spec.ts
+++ b/src/app/components/containers/flow-container/sankey/sankey.component.spec.ts
@@ -37,6 +37,14 @@ describe('SankeyComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should handle sankey with circular links', () => {
+    spyOn(component.child, 'createChart').and.callThrough();
+    component.sankeyData = Mocks.SankeyCircular;
+    fixture.detectChanges();
+    expect(component.child.createChart).toHaveBeenCalled();
+    expect(component.child.svg).toBeTruthy();
+  });
+
   describe('element', () => {
     it('should return the native element', () => {
       expect(component.child.element).toBeTruthy();

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -207,3 +207,8 @@ export const Sankey: SankeyData = {
     link(0, 9),
   ],
 };
+
+export const SankeyCircular: SankeyData = {
+  nodes: [node(0), node(1), node(2)],
+  links: [link(0, 1), link(1, 2), link(2, 0)],
+};


### PR DESCRIPTION
d3-sankey-circular has some limitations and issues where nodes often overlap and links are often formatted strangely. This is a powerful library when circular references are required but can be awkward often. To reduce the number of issues this creates, this PR updates the sankey component to only use the d3-sankey-circular library when circular references are required, otherwise it will use the standard d3 sankey method. 