### PR TITLE
Add title bar links to main page, closes #524

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "factorio-lab",
   "description": "Angular-based calculator for the game Factorio",
-  "version": "1.3.38",
+  "version": "1.3.39",
   "private": true,
   "contributors": [
     "Doug Broad (https://github.com/dcbroad3)"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,11 +8,11 @@
       >
     </div>
     <div class="links">
-      <a target="_blank" href="/factorio">
+      <a target="_blank" href="factorio">
         Factorio
       </a>
       <span class="separator">|</span>
-      <a target="_blank" href="/dsp">
+      <a target="_blank" href="dsp">
         Dyson Sphere Program
       </a>
       <span class="separator">|</span>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,6 +8,14 @@
       >
     </div>
     <div class="links">
+      <a target="_blank" href="/factorio">
+        Factorio
+      </a>
+      <span class="separator">|</span>
+      <a target="_blank" href="/dsp">
+        Dyson Sphere Program
+      </a>
+      <span class="separator">|</span>
       <a target="_blank" href="https://github.com/factoriolab/factorio-lab/wiki"
         >Wiki</a
       >

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,13 +8,8 @@
       >
     </div>
     <div class="links">
-      <a target="_blank" href="factorio">
-        Factorio
-      </a>
-      <span class="separator">|</span>
-      <a target="_blank" href="dsp">
-        Dyson Sphere Program
-      </a>
+      <a *ngIf="(data$ | async).isDsp; else dspLink" target="_blank" href="factorio">Factorio Calculator</a>
+      <ng-template #dspLink><a target="_blank" href="dsp">Dyson Sphere Program Calculator</a></ng-template>
       <span class="separator">|</span>
       <a target="_blank" href="https://github.com/factoriolab/factorio-lab/wiki"
         >Wiki</a


### PR DESCRIPTION
Adds links to Factorio and DSP to the main page for easier swapping between base games

Fixes #524 

![image](https://user-images.githubusercontent.com/399084/123830440-228a4080-d8b8-11eb-92da-1dbd8f6ad6b3.png)
